### PR TITLE
Upgrade base ubuntu and virtual-environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,12 @@
-FROM quay.io/evryfs/base-ubuntu:bionic-20200921
+FROM quay.io/evryfs/base-ubuntu:focal-20201008
 
 ARG RUNNER_VERSION=2.273.5
 
 # This the release tag of virtual-environments: https://github.com/actions/virtual-environments/releases
-ARG VIRTUAL_ENVIRONMENT_VERSION=ubuntu18/20200817.1
+ARG UBUNTU_VERSION=2004
+ENV UBUNTU_VERSION=${UBUNTU_VERSION}
+ARG VIRTUAL_ENVIRONMENT_VERSION=ubuntu20/20201026.1
+ENV VIRTUAL_ENVIRONMENT_VERSION=${VIRTUAL_ENVIRONMENT_VERSION}
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
@@ -11,10 +14,10 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     sudo=1.8.* \
-    lsb-release=9.* \
-    software-properties-common=0.96.* \
+    lsb-release=11.1.* \
+    software-properties-common=0.98.* \
     gnupg-agent=2.2.* \
-    openssh-client=1:7.* \
+    openssh-client=1:8.* \
     make=4.*\
     jq=1.* && \
     apt-get -y clean && \
@@ -37,7 +40,7 @@ RUN curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - && \
 # Copy scripts.
 COPY scripts/install-from-virtual-env /usr/local/bin/install-from-virtual-env
 
-# Install base packages from the virtual environment.
+## Install base packages from the virtual environment.
 RUN install-from-virtual-env basic
 RUN install-from-virtual-env python
 RUN install-from-virtual-env aws

--- a/scripts/install-from-virtual-env
+++ b/scripts/install-from-virtual-env
@@ -5,6 +5,7 @@ set -e
 export METADATA_FILE=/metadatafile
 export HELPER_SCRIPTS=/virtual-environments/images/linux/scripts/helpers
 export SCRIPT_PATH=/virtual-environments/images/linux/scripts/installers
+export INSTALLER_SCRIPT_FOLDER=/virtual-environments/images/linux/scripts/installers
 git config --global advice.detachedHead false
 
 if [ ! -d /virtual-environments ]; then
@@ -14,6 +15,11 @@ fi
 if [ ! -f /etc/apt/trusted.gpg.d/microsoft.gpg ]; then
     chmod +x /virtual-environments/images/linux/scripts/base/repos.sh
     /virtual-environments/images/linux/scripts/base/repos.sh
+fi
+
+if [ ! -f ${INSTALLER_SCRIPT_FOLDER}/toolset.json ]; then
+    cp /virtual-environments/images/linux/toolsets/toolset-${UBUNTU_VERSION}.json ${INSTALLER_SCRIPT_FOLDER}/toolset.json
+    cp /virtual-environments/images/linux/toolsets/toolcache-${UBUNTU_VERSION}.json ${INSTALLER_SCRIPT_FOLDER}/toolcache.json
 fi
 
 if [ -z "$1" ]; then

--- a/scripts/install-from-virtual-env
+++ b/scripts/install-from-virtual-env
@@ -18,8 +18,8 @@ if [ ! -f /etc/apt/trusted.gpg.d/microsoft.gpg ]; then
 fi
 
 if [ ! -f ${INSTALLER_SCRIPT_FOLDER}/toolset.json ]; then
-    cp /virtual-environments/images/linux/toolsets/toolset-${UBUNTU_VERSION}.json ${INSTALLER_SCRIPT_FOLDER}/toolset.json
-    cp /virtual-environments/images/linux/toolsets/toolcache-${UBUNTU_VERSION}.json ${INSTALLER_SCRIPT_FOLDER}/toolcache.json
+    cp /virtual-environments/images/linux/toolsets/toolset-"${UBUNTU_VERSION}".json "${INSTALLER_SCRIPT_FOLDER}"/toolset.json
+    cp /virtual-environments/images/linux/toolsets/toolcache-"${UBUNTU_VERSION}".json "${INSTALLER_SCRIPT_FOLDER}"/toolcache.json
 fi
 
 if [ -z "$1" ]; then
@@ -34,5 +34,4 @@ fi
 
 chmod +x ${SCRIPT_PATH}/"${SCRIPT}"
 ${SCRIPT_PATH}/"${SCRIPT}"
-
 


### PR DESCRIPTION
Make it compatible with the latest changes happened on virtual-environment repo.
It seems that the `toolset.json` file: https://github.com/actions/virtual-environments/blob/main/images/linux/scripts/installers/Install-Toolset.ps1 is used to install some toolset packages, it is explained here: https://github.com/actions/virtual-environments/pull/1121

From what i understood, we can safely avoid it, also because to install that script we need poweshell, but sadly it is installed with snap and currently powershell is not yet officially released as an apt package, we could take something here: https://github.com/PowerShell/PowerShell-Docker/blob/master/release/preview/ubuntu20.04/docker/Dockerfile

refs #30 and #29 