### PR TITLE
Fix/change uid gid and version bump

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM quay.io/evryfs/base-ubuntu:focal-20210827
 
 # This the release tag of virtual-environments: https://github.com/actions/virtual-environments/releases
 ARG UBUNTU_VERSION=2004
-ARG VIRTUAL_ENVIRONMENT_VERSION=ubuntu20/20210816.1
+ARG VIRTUAL_ENVIRONMENT_VERSION=ubuntu20/20210831.9
 
 ENV UBUNTU_VERSION=${UBUNTU_VERSION} VIRTUAL_ENVIRONMENT_VERSION=${VIRTUAL_ENVIRONMENT_VERSION}
 
@@ -58,7 +58,7 @@ RUN apt-get -y update && \
     rm -rf /virtual-environments /var/cache/apt /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 # Install runner and its dependencies.
-RUN useradd -mr -d /home/runner runner && \
+RUN groupadd -g 121 runner && useradd -mr -d /home/runner -u 1001 -g 121 runner && \
     install-runner
 
 COPY entrypoint.sh /

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM quay.io/evryfs/base-ubuntu:focal-20210827
 
 # This the release tag of virtual-environments: https://github.com/actions/virtual-environments/releases
 ARG UBUNTU_VERSION=2004
-ARG VIRTUAL_ENVIRONMENT_VERSION=ubuntu20/20210831.9
+ARG VIRTUAL_ENVIRONMENT_VERSION=ubuntu20/20210906.1
 
 ENV UBUNTU_VERSION=${UBUNTU_VERSION} VIRTUAL_ENVIRONMENT_VERSION=${VIRTUAL_ENVIRONMENT_VERSION}
 

--- a/tag.sh
+++ b/tag.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-RUNNER_VERSION=$(grep "ARG RUNNER_VERSION" -F Dockerfile |cut -d = -f 2)
 VIRTUAL_ENVIRONMENT_VERSION=$(grep "ARG VIRTUAL_ENVIRONMENT_VERSION" -F Dockerfile| cut -d = -f 2 | sed s/\\//-/)
-TAG=${VIRTUAL_ENVIRONMENT_VERSION}-${RUNNER_VERSION}
+TAG=${VIRTUAL_ENVIRONMENT_VERSION}
 
 git tag "${TAG}"


### PR DESCRIPTION
Since https://github.com/evryfs/github-actions-runner/pull/73 is in effect, the tag script should be deprecated.

Fixes https://github.com/evryfs/github-actions-runner/issues/79, new runner release requested in https://github.com/evryfs/github-actions-runner/issues/81 will but built aswell. I'll just tag this one manually when merged.