### PR TITLE
Update to 20210913.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM quay.io/evryfs/base-ubuntu:focal-20210827
 
 # This the release tag of virtual-environments: https://github.com/actions/virtual-environments/releases
 ARG UBUNTU_VERSION=2004
-ARG VIRTUAL_ENVIRONMENT_VERSION=ubuntu20/20210906.1
+ARG VIRTUAL_ENVIRONMENT_VERSION=ubuntu20/20210913.1
 
 ENV UBUNTU_VERSION=${UBUNTU_VERSION} VIRTUAL_ENVIRONMENT_VERSION=${VIRTUAL_ENVIRONMENT_VERSION}
 


### PR DESCRIPTION
Virtual-environments release: https://github.com/actions/virtual-environments/releases/tag/ubuntu20%2F20210913.1

This build will also fetch the latest Runner release: https://github.com/actions/runner/releases/tag/v2.282.1