### PR TITLE
fix runner re-registration issue

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -18,5 +18,8 @@ fi
 
 sudo install-runner
 
-./config.sh --unattended --replace --url "${RUNNER_URL}" --token "${RUNNER_TOKEN}"
+# Reconfigure from the clean state in case of runner failures/restarts
+./config.sh remove --token "${RUNNER_TOKEN}"
+./config.sh --unattended --url "${RUNNER_URL}" --token "${RUNNER_TOKEN}"
+
 exec "./run.sh" "${RUNNER_ARGS}"


### PR DESCRIPTION
Fix
```
-----------------------------
 Finish Install Dependencies
-----------------------------

--------------------------------------------------------------------------------
|        ____ _ _   _   _       _          _        _   _                      |
|       / ___(_) |_| | | |_   _| |__      / \   ___| |_(_) ___  _ __  ___      |
|      | |  _| | __| |_| | | | | '_ \    / _ \ / __| __| |/ _ \| '_ \/ __|     |
|      | |_| | | |_|  _  | |_| | |_) |  / ___ \ (__| |_| | (_) | | | \__ \     |
|       \____|_|\__|_| |_|\__,_|_.__/  /_/   \_\___|\__|_|\___/|_| |_|___/     |
|                                                                              |
|                       Self-hosted runner registration                        |
|                                                                              |
--------------------------------------------------------------------------------
Cannot configure the runner because it is already configured. To reconfigure the runner, run 'config.cmd remove' or './config.sh remove' first.
```