### PR TITLE
Add gh as there's no action for it

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN \
     curl -sL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | tee /etc/apt/trusted.gpg.d/microsoft.gpg > /dev/null && \
     AZ_REPO=$(lsb_release -cs) ; echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $AZ_REPO main" | tee /etc/apt/sources.list.d/azure-cli.list && \
     # github cli
-    curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg && \
+    curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg && \
     echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null && \
     apt-get update && \
     # Install libs required for cyress: https://docs.cypress.io/guides/getting-started/installing-cypress#System-requirements

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN \
     AZ_REPO=$(lsb_release -cs) ; echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $AZ_REPO main" | tee /etc/apt/sources.list.d/azure-cli.list && \
     # github cli
     curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg && \
-    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null && \
     apt-get update && \
     # Install libs required for cyress: https://docs.cypress.io/guides/getting-started/installing-cypress#System-requirements
     apt-get -y install --no-install-recommends \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,10 @@ ENV LANG=C.UTF-8
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-# Add sudo rule for runner user
-RUN echo "runner ALL= EXEC: NOPASSWD:ALL" >> /etc/sudoers.d/runner
 
 RUN \
+    # Add sudo rule for runner user
+    echo "runner ALL= EXEC: NOPASSWD:ALL" >> /etc/sudoers.d/runner && \
     # azure-cli
     curl -sL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | tee /etc/apt/trusted.gpg.d/microsoft.gpg > /dev/null && \
     AZ_REPO=$(lsb_release -cs) ; echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $AZ_REPO main" | tee /etc/apt/sources.list.d/azure-cli.list && \
@@ -25,11 +25,9 @@ RUN \
     ln -sf /opt/yarn-v${YARN_VERSION}/bin/yarn /usr/local/bin/yarn && \
 	ln -sf /opt/yarn-v${YARN_VERSION}/bin/yarnpkg /usr/local/bin/yarnpkg && \
     apt-get -y clean && \
-    rm -rf /var/cache/apt /var/lib/apt/lists/* /tmp/* /var/tmp/*
-
-
-# Add runner user with gid 121 and uid 1001, so it is equal to the runner images used by GitHub
-RUN groupadd -g 121 runner && useradd -mr -d /actions-runner -u 1001 -g 121 runner
+    rm -rf /var/cache/apt /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
+    # Add runner user with gid 121 and uid 1001, so it is equal to the runner images used by GitHub
+    groupadd -g 121 runner && useradd -mr -d /actions-runner -u 1001 -g 121 runner
 
 WORKDIR /actions-runner
 USER runner


### PR DESCRIPTION
Installs github cli. There's no official action to use, as it's installed by default in all gh runners.