### PR TITLE
Follow redirects

### DIFF
--- a/.github/workflows/updater.yml
+++ b/.github/workflows/updater.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Check for updates
       id: update
       run: |
-        version=$(curl --silent https://api.github.com/repos/actions/virtual-environments/releases | \
+        version=$(curl --location --silent https://api.github.com/repos/actions/virtual-environments/releases | \
           jq -r 'map(select(.tag_name|startswith("ubuntu20"))|.tag_name)[0]')
 
         echo ::set-output name=version::$version


### PR DESCRIPTION
GitHub has changed this endpoint to redirect to another https://api.github.com/repositories/{repo_id}/releases

```sh
curl -I https://api.github.com/repos/actions/virtual-environments/releases
HTTP/2 301
server: GitHub.com
date: Thu, 11 Aug 2022 01:17:02 GMT
content-type: application/json; charset=utf-8
content-length: 173
location: https://api.github.com/repositories/190416463/releases
x-github-media-type: github.v3; format=json
access-control-expose-headers: ETag, Link, Location, Retry-After, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Used, X-RateLimit-Resource, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval, X-GitHub-Media-Type, X-GitHub-SSO, X-GitHub-Request-Id, Deprecation, Sunset
access-control-allow-origin: *
strict-transport-security: max-age=31536000; includeSubdomains; preload
x-frame-options: deny
x-content-type-options: nosniff
x-xss-protection: 0
referrer-policy: origin-when-cross-origin, strict-origin-when-cross-origin
content-security-policy: default-src 'none'
vary: Accept-Encoding, Accept, X-Requested-With
x-ratelimit-limit: 60
x-ratelimit-remaining: 51
x-ratelimit-reset: 1660181495
x-ratelimit-resource: core
x-ratelimit-used: 9
x-github-request-id: E43D:275E:A63F75:1743028:62F4588E

```

```sh
% curl --silent https://api.github.com/repos/actions/virtual-environments/releases | \
    jq -r 'map(select(.tag_name|startswith("ubuntu20"))|.tag_name)[0]'
jq: error (at <stdin>:5): Cannot index string with string "tag_name"
% curl -L --silent https://api.github.com/repos/actions/virtual-environments/releases | \
    jq -r 'map(select(.tag_name|startswith("ubuntu20"))|.tag_name)[0]'
ubuntu20/20220807.1
```