### PR TITLE
Get the latest runner version using grep instead of perl

### DIFF
--- a/scripts/install-runner
+++ b/scripts/install-runner
@@ -6,7 +6,7 @@ latest_runner_version=$(curl -I -s \
     --retry ${RETRIES:-3} \
     --retry-connrefused \
     https://github.com/actions/runner/releases/latest 2>&1 |
-  grep -Pio 'location:.*?/v\K.*' |
+  grep -Pio 'location:.*?/v\K.*?$' |
   tr -d '\r')
 
 if [ -e /etc/image_runner_version ]; then

--- a/scripts/install-runner
+++ b/scripts/install-runner
@@ -1,12 +1,13 @@
 #!/bin/bash
 set -e
 
-latest_runner_version=$(curl -L -s \
+latest_runner_version=$(curl -I -s \
     --retry-max-time ${RETRY_MAX_TIME:-60} \
     --retry ${RETRIES:-3} \
     --retry-connrefused \
     https://github.com/actions/runner/releases/latest 2>&1 |
-  grep -oP '<h1.*?>v\K.*?(?=</h1>)')
+  grep -Pio 'location:.*?/v\K.*' |
+  tr -d '\r')
 
 if [ -e /etc/image_runner_version ]; then
   image_runner_version=$(cat /etc/image_runner_version)

--- a/scripts/install-runner
+++ b/scripts/install-runner
@@ -1,12 +1,12 @@
 #!/bin/bash
 set -e
 
-latest_runner_version=$(curl -I -s \
+latest_runner_version=$(curl -L -s \
     --retry-max-time ${RETRY_MAX_TIME:-60} \
     --retry ${RETRIES:-3} \
     --retry-connrefused \
     https://github.com/actions/runner/releases/latest 2>&1 |
-  perl -ne 'next unless s/^location: //; s{.*/v}{}; s/\s+//; print')
+  grep -oP '<h1.*?>v\K.*?(?=</h1>)')
 
 if [ -e /etc/image_runner_version ]; then
   image_runner_version=$(cat /etc/image_runner_version)


### PR DESCRIPTION
## Description

I'm not sure why, but when building a custom runner image, this part of the script is failing resulting in an empty variable which snowballs into the subsequent download and install to fail. I found a better solution using grep that should work well.